### PR TITLE
Update Supabase CLI version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: 1.26.9
 
       - run: supabase start
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: 1.26.9
 
       - run: supabase link --project-ref $PROJECT_ID
       - run: supabase db push

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: 1.26.9
 
       - run: supabase link --project-ref $PROJECT_ID
       - run: supabase db push


### PR DESCRIPTION
## What kind of change does this PR introduce?

Updates the Supabase CLI version to 1.26.9

## What is the current behavior?

Supabase CLI version 1.0.0 will fail when linking due to remote Supabase Postgres 15 migration. 
![Screenshot 2023-01-18 at 09 05 29](https://user-images.githubusercontent.com/37596980/213226902-cb540e88-4a2f-419d-9683-e28a5ca74437.png)

## What is the new behavior?

Supabase CLI commands like ```supabase link``` should work properly

## Additional context

Related to this issue 
https://github.com/supabase/cli/issues/716
