### PR TITLE
fix: pin to latest cli version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.26.9
+          version: latest
 
       - run: supabase start
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: 1.26.9
 
       - run: supabase start
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.26.9
+          version: latest
 
       - run: supabase link --project-ref $PROJECT_ID
       - run: supabase db push

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: 1.26.9
 
       - run: supabase link --project-ref $PROJECT_ID
       - run: supabase db push

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.26.9
+          version: latest
 
       - run: supabase link --project-ref $PROJECT_ID
       - run: supabase db push

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: supabase/setup-cli@v1
         with:
-          version: 1.0.0
+          version: 1.26.9
 
       - run: supabase link --project-ref $PROJECT_ID
       - run: supabase db push


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for Postgres15 migration incompatibility with Supabase CLI 1.0.0.
Change CLI version to latest

## What is the current behavior?

fixes #18 
#14 

## What is the new behavior?

![Screenshot 2023-01-18 at 09 38 56](https://user-images.githubusercontent.com/37596980/213240788-41386445-2ae6-4e46-8a21-4cf8293776d6.png)


## Additional context

Looks like this change is available on other branches, but not main. Since most people will be using the example from the main branch, it would benefit many people.
