### PR TITLE
PoC: preview migration changes on remote branch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,14 @@
   "image": "mcr.microsoft.com/devcontainers/typescript-node:16-bullseye",
   // Features to add to the dev container. More info: https://containers.dev/implementors/features.
   "features": {
+    "github-cli": {},
     "ghcr.io/devcontainers/features/docker-in-docker:1": {}
   },
   // Use 'postCreateCommand' to run commands after the container is created.
   "onCreateCommand": "npx -y supabase start",
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   "forwardPorts": [54321, 54322, 54323, 54324, 54325, 54326],
+  "postAttachCommand": "gh codespace ports visibility 54321:public 54322:public 54323:public 54324:public 54325:public 54326:public -c $CODESPACE_NAME",
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
   "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "Node.js & TypeScript",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:16-bullseye",
+  // Features to add to the dev container. More info: https://containers.dev/implementors/features.
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:1": {}
+  },
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "onCreateCommand": "npx -y supabase start",
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  "forwardPorts": [54321, 54322, 54323, 54324, 54325, 54326],
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+  "containerEnv": {
+    "SUPABASE_INTERNAL_IMAGE_REGISTRY": "ghcr.io"
+  }
+}

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,33 @@
+name: Preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_PAT }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - id: codespace
+        run: |
+          name=$(gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/{owner}/{repo}/pulls/${{ github.event.number }}/codespaces \
+          -F repository_id=${{ github.repository_id }} \
+          --jq ".name")
+          echo "name=$name" >> $GITHUB_OUTPUT
+
+      - run: |
+          gh issue comment ${{ github.event.number }} --edit-last \
+          -b '[Preview](https://${{ steps.codespace.outputs.name }}-54323.preview.app.github.dev) | [Console](https://${{ steps.codespace.outputs.name }}.github.dev)'
+
+      # - run: gh codespace logs -c ${{ steps.codespace.outputs.name }} -f

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -19,7 +19,7 @@ max_rows = 1000
 port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 14
+major_version = 15
 
 [studio]
 # Port to use for Supabase Studio.


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

1. Launches a codespace for each new PR
    - Requires personal access token or github app
    - Limited to 2 _active_ instances per author
3. Codespace runs a devcontainer that starts the CLI local development stack via npx
    - Local ports are forwarded to public internet
    - Instance scales to 0 on inactivity, restarts in about 5 mins
4. Bot comments on PR when the public url is ready

## Additional context

- Does not scale up automatically (need to visit console first)
- New commits on preview branch not automatically pulled
- No status indicator when container is still building (have to visit console page)
