### PR TITLE
PoC: add fly deployment workflow

### DIFF
--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -1,0 +1,23 @@
+name: Fly Preview
+
+on:
+  pull_request:
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      FLY_ORGANIZATION_ID: personal
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: fly m api-proxy -o $FLY_ORGANIZATION_ID &
+      - id: deployment
+        uses: sweatybridge/fly-preview@main
+        env:
+          DB_ONLY: true
+      - run: |
+          gh issue comment ${{ github.event.number }} --edit-last \
+          -b '[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: fly m api-proxy -o $FLY_ORGANIZATION_ID &
+      - run: flyctl m api-proxy -o $FLY_ORGANIZATION_ID &
       - id: deployment
         uses: sweatybridge/fly-preview@main
         env:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -22,8 +22,7 @@ jobs:
           PROJECT_REF: qiao-all-in-one
           DB_ONLY: true
       - run: |
-          body="Status: Deploying ($(date))
-          $COMMENT_BODY"
+          body="Status: [Deploying](https://fly.io/apps/${{ github.head_ref }}) ($(date))"
           exit_code=0
           gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
           if [[ "$exit_code" -gt 0 ]]; then
@@ -31,10 +30,6 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COMMENT_BODY: |2
-            ```bash
-            Console URL: [https://fly.io/apps/${{ github.head_ref }}](https://fly.io/apps/${{ github.head_ref }})
-            ```
       - run: |
           for i in {1..60}; do
             status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status')
@@ -45,14 +40,13 @@ jobs:
             sleep 2
           done
       - run: |
-          body="Status: Ready ($(date))
+          body="Status: [Ready](https://fly.io/apps/${{ github.head_ref }}) ($(date))
           $COMMENT_BODY"
           gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: |2
             ```bash
-            Console URL: [https://fly.io/apps/${{ github.head_ref }}](https://fly.io/apps/${{ github.head_ref }})
                 API URL: http://${{ steps.deployment.outputs.hostname }}
             GraphQL URL: http://${{ steps.deployment.outputs.hostname }}/graphql/v1
                  DB URL: postgresql://postgres:postgres@${{ github.head_ref }}.fly.dev:5432/postgres

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -26,8 +26,11 @@ jobs:
         uses: sweatybridge/fly-preview@main
         env:
           DB_ONLY: true
+      - run: echo "PREVIEW_BRANCH=${DEPLOYMENT_URL%.fly.dev}" >> "$GITHUB_ENV"
+        env:
+          DEPLOYMENT_URL: ${{ steps.deployment.outputs.hostname }}
       - run: |
-          body="Status: [Deploying](https://fly.io/apps/${NEXT_PUBLIC_SUPABASE_URL%.fly.dev}) ($(date))"
+          body="Status: [Deploying](https://fly.io/apps/$PREVIEW_BRANCH) ($(date))"
           exit_code=0
           gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
           if [[ "$exit_code" -gt 0 ]]; then
@@ -38,7 +41,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: |
           for i in {1..60}; do
-            status=$(flyctl m list -a "${NEXT_PUBLIC_SUPABASE_URL%.fly.dev}" --json | jq -r 'map(.checks)[0][0].status') || true
+            status=$(flyctl m list -a "$PREVIEW_BRANCH" --json | jq -r 'map(.checks)[0][0].status') || true
             if [ "$status" == 'passing' ]; then
               break
             fi
@@ -46,7 +49,7 @@ jobs:
             sleep 2
           done
       - run: |
-          body="Status: [Ready](https://fly.io/apps/${NEXT_PUBLIC_SUPABASE_URL%.fly.dev}) ($(date))
+          body="Status: [Ready](https://fly.io/apps/$PREVIEW_BRANCH) ($(date))
           $COMMENT_BODY"
           gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -22,7 +22,7 @@ jobs:
           PROJECT_REF: qiao-all-in-one
           DB_ONLY: true
       - run: |
-          body='[Deploying...](https://fly.io/apps/${{ github.head_ref }})'
+          body="Status: Deploying ($(date))\n$COMMENT_BODY"
           exit_code=0
           gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
           if [[ "$exit_code" -gt 0 ]]; then
@@ -30,6 +30,8 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: |2
+            Console URL: https://fly.io/apps/${{ github.head_ref }}
       - run: |
           for i in {1..60}; do
             status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status')
@@ -40,12 +42,18 @@ jobs:
             sleep 2
           done
       - run: |
-          body='[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'
+          body="Status: Ready ($(date))\n$COMMENT_BODY"
           gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_BODY: |2
+            Console URL: https://fly.io/apps/${{ github.head_ref }}
+                API URL: http://${{ steps.deployment.outputs.hostname }}
+            GraphQL URL: http://${{ steps.deployment.outputs.hostname }}/graphql/v1
+                 DB URL: postgresql://postgres:postgres@${{ github.head_ref }}.fly.dev:5432/postgres
+               anon key: ${{ steps.deployment.outputs.anon_key }}
       - uses: supabase/setup-cli@v1
         with:
           version: latest
-      # - run: |
-      #     supabase db push --db-url 'postgres://postgres:postgres@${{ steps.deployment.outputs.hostname }}/postgres'
+      - run: |
+          supabase db push --db-url 'postgres://postgres:postgres@${{ steps.deployment.outputs.hostname }}/postgres'

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -22,7 +22,8 @@ jobs:
           PROJECT_REF: qiao-all-in-one
           DB_ONLY: true
       - run: |
-          body="Status: Deploying ($(date))\n$COMMENT_BODY"
+          body="Status: Deploying ($(date))
+          $COMMENT_BODY"
           exit_code=0
           gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
           if [[ "$exit_code" -gt 0 ]]; then
@@ -31,7 +32,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: |2
-            Console URL: https://fly.io/apps/${{ github.head_ref }}
+            ```bash
+            Console URL: [https://fly.io/apps/${{ github.head_ref }}](https://fly.io/apps/${{ github.head_ref }})
+            ```
       - run: |
           for i in {1..60}; do
             status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status')
@@ -42,16 +45,19 @@ jobs:
             sleep 2
           done
       - run: |
-          body="Status: Ready ($(date))\n$COMMENT_BODY"
+          body="Status: Ready ($(date))
+          $COMMENT_BODY"
           gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_BODY: |2
-            Console URL: https://fly.io/apps/${{ github.head_ref }}
+            ```bash
+            Console URL: [https://fly.io/apps/${{ github.head_ref }}](https://fly.io/apps/${{ github.head_ref }})
                 API URL: http://${{ steps.deployment.outputs.hostname }}
             GraphQL URL: http://${{ steps.deployment.outputs.hostname }}/graphql/v1
                  DB URL: postgresql://postgres:postgres@${{ github.head_ref }}.fly.dev:5432/postgres
                anon key: ${{ steps.deployment.outputs.anon_key }}
+            ```
       - uses: supabase/setup-cli@v1
         with:
           version: latest

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -20,7 +20,10 @@ jobs:
         env:
           DB_ONLY: true
       - run: |
-          gh issue comment ${{ github.event.number }} --edit-last \
-          -b '[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'
+          body='[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'
+          gh issue comment ${{ github.event.number }} --edit-last -b "$body"
+          if [[ "$?" -gt 0 ]]; then
+            gh issue comment ${{ github.event.number }} -b "$body"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -9,7 +9,8 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       FLY_ORGANIZATION_ID: D307G6NwgR0z2u4vPG23jYy8a3cg3xbYR
-
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
@@ -21,3 +22,5 @@ jobs:
       - run: |
           gh issue comment ${{ github.event.number }} --edit-last \
           -b '[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -19,8 +19,7 @@ jobs:
         with:
           version: latest
       - run: |
-          supabase login
-          supabase gen keys --project-ref "$PROJECT_REF" --experimental >> "$GITHUB_ENV"
+          supabase gen keys --project-ref cimpzzikygouamvsjwxa --experimental >> "$GITHUB_ENV"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       - id: deployment

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl m api-proxy -o $FLY_ORGANIZATION_ID &
+      - run: flyctl m api-proxy -o personal &
       - id: deployment
         uses: sweatybridge/fly-preview@main
         env:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -27,7 +27,7 @@ jobs:
         env:
           DB_ONLY: true
       - run: |
-          body="Status: [Deploying](https://fly.io/apps/$PROJECT_REF-${{ github.head_ref }}) ($(date))"
+          body="Status: [Deploying](https://fly.io/apps/${NEXT_PUBLIC_SUPABASE_URL%.fly.dev}) ($(date))"
           exit_code=0
           gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
           if [[ "$exit_code" -gt 0 ]]; then
@@ -38,7 +38,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: |
           for i in {1..60}; do
-            status=$(flyctl m list -a "$PROJECT_REF-${{ github.head_ref }}" --json | jq -r 'map(.checks)[0][0].status') || true
+            status=$(flyctl m list -a "${NEXT_PUBLIC_SUPABASE_URL%.fly.dev}" --json | jq -r 'map(.checks)[0][0].status') || true
             if [ "$status" == 'passing' ]; then
               break
             fi
@@ -46,7 +46,7 @@ jobs:
             sleep 2
           done
       - run: |
-          body="Status: [Ready](https://fly.io/apps/$PROJECT_REF-${{ github.head_ref }}) ($(date))
+          body="Status: [Ready](https://fly.io/apps/${NEXT_PUBLIC_SUPABASE_URL%.fly.dev}) ($(date))
           $COMMENT_BODY"
           gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -14,7 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl m api-proxy -o "$FLY_ORGANIZATION_SLUG" &
       - id: deployment
         uses: sweatybridge/fly-preview@main
         env:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -10,7 +10,7 @@ jobs:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       FLY_ORGANIZATION_SLUG: supabase-dev
       # Specifies the base project to branch from
-      PROJECT_REF: qiao-all-in-one
+      # PROJECT_REF: qiao-all-in-one
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -21,8 +21,9 @@ jobs:
           DB_ONLY: true
       - run: |
           body='[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'
-          gh issue comment ${{ github.event.number }} --edit-last -b "$body"
-          if [[ "$?" -gt 0 ]]; then
+          exit_code=0
+          gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
+          if [[ "$exit_code" -gt 0 ]]; then
             gh issue comment ${{ github.event.number }} -b "$body"
           fi
         env:

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -9,18 +9,26 @@ jobs:
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       FLY_ORGANIZATION_SLUG: supabase-dev
+      # Specifies the base project to branch from
+      PROJECT_REF: qiao-all-in-one
     permissions:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - run: |
+          supabase login
+          supabase gen keys --project-ref "$PROJECT_REF" --experimental >> "$GITHUB_ENV"
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       - id: deployment
         uses: sweatybridge/fly-preview@main
         env:
-          # Specifies the base project to branch from
-          PROJECT_REF: qiao-all-in-one
           DB_ONLY: true
       - run: |
-          body="Status: [Deploying](https://fly.io/apps/${{ github.head_ref }}) ($(date))"
+          body="Status: [Deploying](https://fly.io/apps/$PROJECT_REF-${{ github.head_ref }}) ($(date))"
           exit_code=0
           gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
           if [[ "$exit_code" -gt 0 ]]; then
@@ -31,7 +39,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: |
           for i in {1..60}; do
-            status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status') || true
+            status=$(flyctl m list -a "$PROJECT_REF-${{ github.head_ref }}" --json | jq -r 'map(.checks)[0][0].status') || true
             if [ "$status" == 'passing' ]; then
               break
             fi
@@ -39,7 +47,7 @@ jobs:
             sleep 2
           done
       - run: |
-          body="Status: [Ready](https://fly.io/apps/${{ github.head_ref }}) ($(date))
+          body="Status: [Ready](https://fly.io/apps/$PROJECT_REF-${{ github.head_ref }}) ($(date))
           $COMMENT_BODY"
           gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:
@@ -48,11 +56,6 @@ jobs:
             ```bash
                 API URL: http://${{ steps.deployment.outputs.hostname }}
             GraphQL URL: http://${{ steps.deployment.outputs.hostname }}/graphql/v1
-                 DB URL: postgresql://postgres:postgres@${{ github.head_ref }}.fly.dev:5432/postgres
-               anon key: ${{ steps.deployment.outputs.anon_key }}
             ```
-      - uses: supabase/setup-cli@v1
-        with:
-          version: latest
       - run: |
-          supabase db push --db-url 'postgres://postgres:postgres@${{ steps.deployment.outputs.hostname }}/postgres'
+          supabase db push --db-url "postgres://postgres:$SUPABASE_DB_PASSWORD@${{ steps.deployment.outputs.hostname }}/postgres"

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      FLY_ORGANIZATION_ID: personal
+      FLY_ORGANIZATION_ID: D307G6NwgR0z2u4vPG23jYy8a3cg3xbYR
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -13,7 +13,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
-      - uses: superfly/flyctl-actions/setup-flyctl@master
       - id: deployment
         uses: sweatybridge/fly-preview@main
         env:
@@ -29,6 +28,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: |
           for i in {1..60}; do
             status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status') || true

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           version: latest
       - run: |
-          supabase gen keys --project-ref cimpzzikygouamvsjwxa --experimental >> "$GITHUB_ENV"
+          supabase gen keys --project-ref cimpzzikygouamvsjwxa --experimental | sed -E 's|^(.*)="(.*)"$|\1=\2|g' >> "$GITHUB_ENV"
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       - id: deployment

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -42,3 +42,8 @@ jobs:
           gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      - run: |
+          supabase db push --db-url 'postgres://postgres:postgres@${{ steps.deployment.outputs.hostname }}/postgres'

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -20,11 +20,25 @@ jobs:
         env:
           DB_ONLY: true
       - run: |
-          body='[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'
+          body='[Deploying...](https://fly.io/apps/${{ github.head_ref }})'
           exit_code=0
           gh issue comment ${{ github.event.number }} --edit-last -b "$body" || exit_code=$?
           if [[ "$exit_code" -gt 0 ]]; then
             gh issue comment ${{ github.event.number }} -b "$body"
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          for i in {1..60}; do
+            status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status')
+            if [ "$status" == 'passing' ]; then
+              break
+            fi
+            echo "project not ready: $status"
+            sleep 2
+          done
+      - run: |
+          body='[Preview](https://${{ steps.deployment.outputs.hostname }}) | [Console](https://fly.io/apps/${{ github.head_ref }})'
+          gh issue comment ${{ github.event.number }} --edit-last -b "$body"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -23,9 +23,9 @@ jobs:
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       - id: deployment
-        uses: sweatybridge/fly-preview@main
-        env:
-          DB_ONLY: true
+        uses: supabase/fly-preview@sweatybridge-patch-1
+        # env:
+        #   DB_ONLY: true
       - run: echo "PREVIEW_BRANCH=${DEPLOYMENT_URL%.fly.dev}" >> "$GITHUB_ENV"
         env:
           DEPLOYMENT_URL: ${{ steps.deployment.outputs.hostname }}

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -31,7 +31,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: |
           for i in {1..60}; do
-            status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status')
+            status=$(flyctl m list -a ${{ github.head_ref }} --json | jq -r 'map(.checks)[0][0].status') || true
             if [ "$status" == 'passing' ]; then
               break
             fi

--- a/.github/workflows/fly.yaml
+++ b/.github/workflows/fly.yaml
@@ -8,16 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     env:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-      FLY_ORGANIZATION_ID: D307G6NwgR0z2u4vPG23jYy8a3cg3xbYR
+      FLY_ORGANIZATION_SLUG: supabase-dev
     permissions:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl m api-proxy -o personal &
+      - run: flyctl m api-proxy -o "$FLY_ORGANIZATION_SLUG" &
       - id: deployment
         uses: sweatybridge/fly-preview@main
         env:
+          # Specifies the base project to branch from
+          PROJECT_REF: qiao-all-in-one
           DB_ONLY: true
       - run: |
           body='[Deploying...](https://fly.io/apps/${{ github.head_ref }})'
@@ -45,5 +47,5 @@ jobs:
       - uses: supabase/setup-cli@v1
         with:
           version: latest
-      - run: |
-          supabase db push --db-url 'postgres://postgres:postgres@${{ steps.deployment.outputs.hostname }}/postgres'
+      # - run: |
+      #     supabase db push --db-url 'postgres://postgres:postgres@${{ steps.deployment.outputs.hostname }}/postgres'


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

- forks off the volume of an existing supabase fly project
- deploys a new project named after the PR branch
- reports deployment status as PR comment

## Additional context

- Currently does a `DB_ONLY` fork, but it's easy to extend with kong api support.
- When forking off production db, users must ensure their db password are not shared publicly.

TODO:
- [ ] reset password after volume forking
