### PR TITLE
Changed actions to match the variable specified in https://supabase.c…

### DIFF
--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.PRODUCTION_DB_PASSWORD }}
-      PROJECT_ID: jgcajpecsmkatlbzsstn
+      PRODUCTION_PROJECT_ID: ${{ secrets.PRODUCTION_PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -13,7 +13,7 @@ jobs:
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_DB_PASSWORD: ${{ secrets.STAGING_DB_PASSWORD }}
-      PROJECT_ID: cimpzzikygouamvsjwxa
+      STAGING_PROJECT_ID: ${{ secrets.STAGING_PROJECT_ID }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Changed actions to match the variable specified in https://supabase.com/docs/guides/cli/managing-environments

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Tutorial (https://supabase.com/docs/guides/cli/managing-environments) asks to create 5 secrets, but two are not used, and it does not run with the placeholder 'abcdef..' anyway.

## What is the new behavior?

it works with the secrets requested in the tutorial

