### PR TITLE
chore: dry run migration push in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,23 @@ jobs:
             exit 1
           fi
 
+  dryrun:
+    runs-on: ubuntu-latest
+    env:
+      SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+      SUPABASE_DB_PASSWORD: ${{ github.ref == 'refs/heads/main' && secrets.PRODUCTION_DB_PASSWORD || secrets.STAGING_DB_PASSWORD }}
+      SUPABASE_PROJECT_ID: ${{ github.ref == 'refs/heads/main' && secrets.PRODUCTION_PROJECT_ID || secrets.STAGING_PROJECT_ID }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - run: supabase link --project-ref $SUPABASE_PROJECT_ID
+      - run: supabase db push --dry-run
+
   # Adapted from: https://github.com/marketplace/actions/hashicorp-setup-terraform
   plan:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -21,6 +21,12 @@ jobs:
     defaults:
       run:
         working-directory: supabase/remotes
+    outputs:
+      db_url: postgres://${{ steps.branch.outputs.user }}:${{ steps.branch.outputs.password }}@${{ steps.branch.outputs.host }}:${{ steps.branch.outputs.port }}/postgres
+      jwt_secret: ${{ steps.branch.outputs.jwt_secret }}
+      ref: ${{ steps.branch.outputs.id }}
+      status: ${{ steps.branch.outputs.status }}
+      version: ${{ steps.branch.outputs.version }}
 
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +36,30 @@ jobs:
 
       - run: terraform init
       - run: terraform apply -auto-approve -no-color
+      - id: branch
+        run: |
+          terraform output -json branch_database \
+          | jq -r "to_entries|map(\"\(.key)=\(.value|tostring)\")|.[]" \
+          >> "$GITHUB_OUTPUT"
 
-      - if: github.event.pull_request.merged == true
+      - if: github.event.action == 'closed'
         run: terraform apply -auto-approve -no-color -destroy
+
+  migrate:
+    depends_on:
+      - apply
+    runs-on: ubuntu-latest
+    if: github.event.action != 'closed'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - uses: nick-fields/retry@v3
+        with:
+          timeout_seconds: 15
+          max_attempts: 10
+          command: supabase db push --db-url "${{ needs.apply.outputs.db_url }}"

--- a/supabase/remotes/preview.tf
+++ b/supabase/remotes/preview.tf
@@ -35,3 +35,8 @@ resource "supabase_settings" "preview" {
     site_url = "http://localhost:3001"
   })
 }
+
+output "branch_database" {
+  value     = one(supabase_branch.new[*].database)
+  sensitive = true
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

ci

## What is the new behavior?

Using `db push --dry-run` helps catch errors where migration timestamp are out of sync.

## Additional context

Add any other context or screenshots.
