### PR TITLE
Update 20220810154537_new_employee.sql

### DIFF
--- a/supabase/migrations/20220810154537_new_employee.sql
+++ b/supabase/migrations/20220810154537_new_employee.sql
@@ -2,5 +2,3 @@ create table public.employees (
     id integer primary key generated always as identity,
     name text
 );
-
-create index concurrently name_idx ON public.employees (name);

--- a/supabase/migrations/20220810154537_new_employee.sql
+++ b/supabase/migrations/20220810154537_new_employee.sql
@@ -2,3 +2,5 @@ create table public.employees (
     id integer primary key generated always as identity,
     name text
 );
+
+create index concurrently name_idx ON public.employees (name);

--- a/supabase/migrations/20241120053534_add_index.sql
+++ b/supabase/migrations/20241120053534_add_index.sql
@@ -1,0 +1,1 @@
+create index concurrently name_idx ON public.employees (name);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

`create index concurrently ...` cannot be used in the same transaction that creates the table.

## Additional context

Add any other context or screenshots.
